### PR TITLE
EPEL has a newer checksec, no longer need `if` blocks

### DIFF
--- a/fermilab-util_kcron.spec
+++ b/fermilab-util_kcron.spec
@@ -93,19 +93,6 @@ fi
 
 %if %{_hardened_build}
 for code in $(ls %{buildroot}%{_libexecdir}/kcron); do
-    %if (0%{?rhel} && (0%{?rhel} < 9))
-    checksec --file %{buildroot}%{_libexecdir}/kcron/${code}
-    if [[ $? -ne 0 ]]; then
-      exit 1
-    fi
-
-    checksec --fortify-file %{buildroot}%{_libexecdir}/kcron/${code}
-    if [[ $? -ne 0 ]]; then
-      exit 1
-    fi
-
-    %else
-
     checksec --file=%{buildroot}%{_libexecdir}/kcron/${code}
     if [[ $? -ne 0 ]]; then
       exit 1
@@ -115,9 +102,9 @@ for code in $(ls %{buildroot}%{_libexecdir}/kcron); do
     if [[ $? -ne 0 ]]; then
       exit 1
     fi
-    %endif
 done
 %endif
+
 
 %files
 %defattr(0644,root,root,0755)


### PR DESCRIPTION
This should make the spec file easier as there is now a single syntax for use of `checksec` to examine the binaries.